### PR TITLE
Settings: Ignore process kill receiver events if activity is destroyed.

### DIFF
--- a/src/com/android/settings/applications/InstalledAppDetails.java
+++ b/src/com/android/settings/applications/InstalledAppDetails.java
@@ -1019,8 +1019,10 @@ public class InstalledAppDetails extends AppInfoBase
     private final BroadcastReceiver mCheckKillProcessesReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            updateForceStopButton(getResultCode() != Activity.RESULT_CANCELED);
-            refreshUi();
+            if (getActivity() != null && !getActivity().isDestroyed()) {
+                updateForceStopButton(getResultCode() != Activity.RESULT_CANCELED);
+                refreshUi();
+            }
         }
     };
 


### PR DESCRIPTION
  Following the logic for refresh ui attempts to getContext() from the
  underlying activity which may have already been destroyed causing
  an NPE.

Change-Id: Ibe110022ebedcc55a01f3bda66501580c8d92fed
TICKET: NIGHTLIES-2935